### PR TITLE
 Improved account setup workflow

### DIFF
--- a/pages/settings.js
+++ b/pages/settings.js
@@ -1,17 +1,33 @@
 import { useContext } from 'react'
-import Layout from '@components/Layout'
+import { useRouter } from 'next/router'
+import Button from '@material-ui/core/Button'
+import SaveIcon from '@material-ui/icons/Save'
 import { AuthenticationContext } from 'gitea-react-toolkit'
+import Layout from '@components/Layout'
 import TranslationSettings from '@components/TranslationSettings'
 
 const SettingsPage = () => {
+  const router = useRouter()
   const { state: authentication } = useContext(AuthenticationContext)
 
   return (
     <Layout>
       <div className='flex flex-col justify-center items-center'>
         <div className='flex flex-col w-full px-4 lg:w-132 lg:p-0'>
-          <h1>Account Settings</h1>
+          <h1 className='mx-4'>Account Settings</h1>
           <TranslationSettings authentication={authentication} />
+          <div className='flex justify-end'>
+            <Button
+              size='large'
+              color='primary'
+              className='my-3'
+              variant='contained'
+              onClick={() => router.push('/')}
+              startIcon={<SaveIcon />}
+            >
+              Save and Continue
+            </Button>
+          </div>
         </div>
       </div>
     </Layout>

--- a/pages/settings.js
+++ b/pages/settings.js
@@ -1,0 +1,21 @@
+import { useContext } from 'react'
+import Layout from '@components/Layout'
+import { AuthenticationContext } from 'gitea-react-toolkit'
+import TranslationSettings from '@components/TranslationSettings'
+
+const SettingsPage = () => {
+  const { state: authentication } = useContext(AuthenticationContext)
+
+  return (
+    <Layout>
+      <div className='flex flex-col justify-center items-center'>
+        <div className='flex flex-col w-full px-4 lg:w-132 lg:p-0'>
+          <h1>Account Settings</h1>
+          <TranslationSettings authentication={authentication} />
+        </div>
+      </div>
+    </Layout>
+  )
+}
+
+export default SettingsPage

--- a/src/components/AccountSetup.js
+++ b/src/components/AccountSetup.js
@@ -1,66 +1,21 @@
-import React, { useState, useEffect, useContext } from 'react'
+import React, { useContext } from 'react'
 import PropTypes from 'prop-types'
-import Paper from 'translation-helps-rcl/dist/components/Paper'
-import FormControl from '@material-ui/core/FormControl'
-import { makeStyles } from '@material-ui/core/styles'
-import InputLabel from '@material-ui/core/InputLabel'
-import MenuItem from '@material-ui/core/MenuItem'
-import Select from '@material-ui/core/Select'
-// import Button from '@material-ui/core/Button'
-import { getGatewayLanguages } from '@common/languages'
+import Button from '@material-ui/core/Button'
+import { Paper } from 'translation-helps-rcl'
 import { ReferenceContext } from '@context/ReferenceContext'
-
-const useStyles = makeStyles(theme => ({
-  formControl: {
-    marginTop: theme.spacing(3),
-    marginBottom: theme.spacing(3),
-    minWidth: '100%',
-  },
-}))
+import TranslationSettings from '@components/TranslationSettings'
 
 function AccountSetup({ authentication }) {
-  const classes = useStyles()
-  const [organizations, setOrganizations] = useState([])
-  const [languages, setLanguages] = useState([])
   const {
     state: { owner: organization, languageId },
-    actions: { setOwner: setOrganization, setLanguageId },
+    actions: { setShowAccountSetup },
   } = useContext(ReferenceContext)
 
-  useEffect(() => {
-    async function getOrgs() {
-      const orgs = await fetch('https://git.door43.org/api/v1/user/orgs', {
-        ...authentication.config,
-      })
-        .then(response => response.json())
-        .then(data => data.map(org => org.username))
-      setOrganizations(orgs)
-    }
-
-    if (authentication) {
-      getOrgs()
-    }
-  }, [authentication])
-
-  useEffect(() => {
-    async function getLanguages() {
-      const languages = await getGatewayLanguages()
-      setLanguages(languages || [])
-    }
-
-    getLanguages()
-  }, [])
-
-  const handleOrgChange = event => {
-    setOrganization(event.target.value)
+  const handleSubmit = () => {
+    setShowAccountSetup(false)
   }
 
-  const handleLanguageChange = event => {
-    setLanguageId(event.target.value)
-  }
-
-  // const handleSubmit = () => {}
-  // const disabledButton = !organization || !languageId
+  const disabledButton = !organization || !languageId
 
   return (
     <div className='flex flex-col justify-center items-center'>
@@ -71,48 +26,8 @@ function AccountSetup({ authentication }) {
             Choose your Organization and Primary Language
           </p>
         </Paper>
-        <Paper className='flex flex-col h-80 w-full p-6 pt-3 my-2'>
-          <h5>Translation Settings</h5>
-          <div className='flex flex-col justify-between my-4'>
-            <FormControl variant='outlined' className={classes.formControl}>
-              <InputLabel id='demo-simple-select-outlined-label'>
-                Organization
-              </InputLabel>
-              <Select
-                labelId='demo-simple-select-outlined-label'
-                id='demo-simple-select-outlined'
-                value={organization}
-                onChange={handleOrgChange}
-                label='Organization'
-              >
-                {organizations.map((org, i) => (
-                  <MenuItem key={`${org}-${i}`} value={org}>
-                    {org}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-            <FormControl variant='outlined' className={classes.formControl}>
-              <InputLabel id='demo-simple-select-outlined-label'>
-                Primary Translating Language
-              </InputLabel>
-              <Select
-                labelId='demo-simple-select-outlined-label'
-                id='demo-simple-select-outlined'
-                value={languageId}
-                onChange={handleLanguageChange}
-                label='Primary Translating Language'
-              >
-                {languages.map(({ languageId, languageName, localized }, i) => (
-                  <MenuItem key={`${languageId}-${i}`} value={languageId}>
-                    {`${languageId} - ${languageName} - ${localized}`}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </div>
-        </Paper>
-        {/* <div className='flex justify-end h-62 w-full'>
+        <TranslationSettings authentication={authentication} />
+        <div className='flex justify-end h-62 w-full'>
           <Button
             className='my-2'
             variant='contained'
@@ -123,7 +38,7 @@ function AccountSetup({ authentication }) {
           >
             Save and Continue
           </Button>
-        </div> */}
+        </div>
       </div>
     </div>
   )

--- a/src/components/AccountSetup.js
+++ b/src/components/AccountSetup.js
@@ -2,6 +2,7 @@ import React, { useContext } from 'react'
 import PropTypes from 'prop-types'
 import Button from '@material-ui/core/Button'
 import { Paper } from 'translation-helps-rcl'
+import SaveIcon from '@material-ui/icons/Save'
 import { ReferenceContext } from '@context/ReferenceContext'
 import TranslationSettings from '@components/TranslationSettings'
 
@@ -29,12 +30,14 @@ function AccountSetup({ authentication }) {
         <TranslationSettings authentication={authentication} />
         <div className='flex justify-end h-62 w-full'>
           <Button
-            className='my-2'
-            variant='contained'
+            size='large'
             color='primary'
+            className='my-2'
             disableElevation
-            disabled={disabledButton}
+            variant='contained'
             onClick={handleSubmit}
+            startIcon={<SaveIcon />}
+            disabled={disabledButton}
           >
             Save and Continue
           </Button>

--- a/src/components/Drawer.js
+++ b/src/components/Drawer.js
@@ -1,20 +1,40 @@
 import React from 'react'
+import { useRouter } from 'next/router'
 import SwipeableDrawer from '@material-ui/core/SwipeableDrawer'
 import ChevronLeftIcon from '@material-ui/icons/ChevronLeft'
 import ListItemIcon from '@material-ui/core/ListItemIcon'
 import ListItemText from '@material-ui/core/ListItemText'
 import ExitToAppIcon from '@material-ui/icons/ExitToApp'
+import SettingsIcon from '@material-ui/icons/Settings'
 import BugReportIcon from '@material-ui/icons/BugReport'
-import DashboardIcon from '@material-ui/icons/Dashboard'
 import IconButton from '@material-ui/core/IconButton'
-import Crop54Icon from '@material-ui/icons/Crop54'
-import FolderIcon from '@material-ui/icons/Folder'
 import ListItem from '@material-ui/core/ListItem'
-import Divider from '@material-ui/core/Divider'
-import Button from '@material-ui/core/Button'
 import List from '@material-ui/core/List'
+// TODO: Enable buttons once ready to fully implement functionality
+// import DashboardIcon from '@material-ui/icons/Dashboard'
+// import Crop54Icon from '@material-ui/icons/Crop54'
+// import FolderIcon from '@material-ui/icons/Folder'
+// import Divider from '@material-ui/core/Divider'
+// import Button from '@material-ui/core/Button'
 
 function Drawer({ open, onClose, onOpen, user, logout }) {
+  const router = useRouter()
+
+  function onSettingsClick() {
+    router.push('/settings')
+    onClose()
+  }
+
+  function onFeedbackClick() {
+    // router.push('/feedback')
+    // onClose()
+  }
+
+  function onLogout() {
+    logout()
+    onClose()
+  }
+
   return (
     <SwipeableDrawer
       anchor='left'
@@ -47,7 +67,15 @@ function Drawer({ open, onClose, onOpen, user, logout }) {
           </h1>
         </div>
       )}
-      <div className='mx-4 mt-2 m-1'>
+      <List disablePadding>
+        <ListItem button key={'Account Settings'} onClick={onSettingsClick}>
+          <ListItemIcon>
+            <SettingsIcon />
+          </ListItemIcon>
+          <ListItemText primary={'Account Settings'} />
+        </ListItem>
+      </List>
+      {/* <div className='mx-4 mt-2 m-1'>
         <Button variant='outlined' startIcon={<FolderIcon />}>
           Save Current Layout
         </Button>
@@ -122,20 +150,26 @@ function Drawer({ open, onClose, onOpen, user, logout }) {
           <ListItemText primary={'My Book Package Flow'} />
         </ListItem>
       </List>
-      <Divider />
+      <Divider /> */}
       <List disablePadding>
-        <ListItem button key={'Bug Report or Feedback'}>
+        <ListItem
+          button
+          key={'Bug Report or Feedback'}
+          onClick={onFeedbackClick}
+        >
           <ListItemIcon>
             <BugReportIcon />
           </ListItemIcon>
           <ListItemText primary={'Bug Report or Feedback'} />
         </ListItem>
-        <ListItem button key={'Logout'} onClick={() => logout()}>
-          <ListItemIcon>
-            <ExitToAppIcon />
-          </ListItemIcon>
-          <ListItemText primary={'Logout'} />
-        </ListItem>
+        {user && (
+          <ListItem button key={'Logout'} onClick={onLogout}>
+            <ListItemIcon>
+              <ExitToAppIcon />
+            </ListItemIcon>
+            <ListItemText primary={'Logout'} />
+          </ListItem>
+        )}
       </List>
     </SwipeableDrawer>
   )

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -4,16 +4,17 @@ import { useRouter } from 'next/router'
 import { makeStyles } from '@material-ui/core/styles'
 import Typography from '@material-ui/core/Typography'
 import IconButton from '@material-ui/core/IconButton'
-import Button from '@material-ui/core/Button'
-import SubmitButton from '@components/SubmitButton'
-import ShareIcon from '@material-ui/icons/Share'
 import Toolbar from '@material-ui/core/Toolbar'
 import MenuIcon from '@material-ui/icons/Menu'
-import LinkIcon from '@material-ui/icons/Link'
 import AppBar from '@material-ui/core/AppBar'
 import Drawer from '@components/Drawer'
 import BibleReference from '@components/BibleReference'
 import { AuthContext } from '@context/AuthContext'
+// TODO: Enable buttons once ready to fully implement functionality
+// import LinkIcon from '@material-ui/icons/Link'
+// import Button from '@material-ui/core/Button'
+// import SubmitButton from '@components/SubmitButton'
+// import ShareIcon from '@material-ui/icons/Share'
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -35,11 +36,14 @@ const useStyles = makeStyles(theme => ({
     cursor: 'pointer',
   },
   navigation: {
-    flexGrow: 1,
+    display: 'flex',
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
 }))
 
-export default function Header({ appName, authentication: { user } }) {
+export default function Header({ title, authentication: { user } }) {
   const classes = useStyles()
   const router = useRouter()
   const [drawerOpen, setOpen] = useState(false)
@@ -58,40 +62,44 @@ export default function Header({ appName, authentication: { user } }) {
     <header>
       <AppBar position='static'>
         <Toolbar>
-          <IconButton
-            edge='start'
-            className={classes.menuButton}
-            color='inherit'
-            aria-label='menu'
-            onClick={handleDrawerOpen}
-          >
-            <MenuIcon />
-          </IconButton>
-          <Typography
-            variant='h6'
-            className={classes.title}
-            onClick={() => router.push('/')}
-          >
-            {appName}
-          </Typography>
+          <div className='flex flex-1 justify-center items-center'>
+            <IconButton
+              edge='start'
+              className={classes.menuButton}
+              color='inherit'
+              aria-label='menu'
+              onClick={handleDrawerOpen}
+            >
+              <MenuIcon />
+            </IconButton>
+            <Typography
+              variant='h6'
+              className={classes.title}
+              onClick={() => router.push('/')}
+            >
+              {title}
+            </Typography>
+          </div>
           <div className={classes.navigation}>
             <BibleReference />
           </div>
-          <Button
-            className={classes.button}
-            variant='outlined'
-            onClick={() => {}}
-          >
-            <LinkIcon classes={{ root: classes.icon }} htmlColor='#ffffff' />
-          </Button>
-          <Button
-            className={classes.button}
-            variant='outlined'
-            onClick={() => {}}
-          >
-            <ShareIcon classes={{ root: classes.icon }} htmlColor='#ffffff' />
-          </Button>
-          <SubmitButton variant='contained' disableElevation active={false} />
+          <div className='flex flex-1 justify-end'>
+            {/* <Button
+              className={classes.button}
+              variant='outlined'
+              onClick={() => {}}
+            >
+              <LinkIcon classes={{ root: classes.icon }} htmlColor='#ffffff' />
+            </Button>
+            <Button
+              className={classes.button}
+              variant='outlined'
+              onClick={() => {}}
+            >
+              <ShareIcon classes={{ root: classes.icon }} htmlColor='#ffffff' />
+            </Button>
+            <SubmitButton variant='contained' disableElevation active={false} /> */}
+          </div>
         </Toolbar>
       </AppBar>
       <Drawer

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -6,24 +6,24 @@ import Footer from '@components/Footer'
 import Onboarding from '@components/Onboarding'
 import { ReferenceContext } from '@context/ReferenceContext'
 
-export default function Layout({ children }) {
+export default function Layout({
+  children,
+  title = 'translationCore: Create',
+}) {
   const {
     state: authentication,
     component: authenticationComponent,
   } = useContext(AuthenticationContext)
 
   const {
-    state: { owner, languageId },
+    state: { showAccountSetup },
   } = useContext(ReferenceContext)
 
   return (
     <div className='h-screen w-screen flex flex-col'>
-      <Header
-        appName='translationCore: Create'
-        authentication={authentication || {}}
-      />
+      <Header title={title} authentication={authentication || {}} />
       <main className='flex flex-1 flex-col w-auto m-0 bg-gray-200'>
-        {authentication && owner && languageId ? (
+        {authentication && !showAccountSetup ? (
           children
         ) : (
           <Onboarding

--- a/src/components/Onboarding.js
+++ b/src/components/Onboarding.js
@@ -1,11 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import dynamic from 'next/dynamic'
-import Paper from 'translation-helps-rcl/dist/components/Paper'
+import { Paper } from 'translation-helps-rcl'
 import CircularProgress from '@components/CircularProgress'
 
 const AccountSetup = dynamic(() => import('@components/AccountSetup'), {
-  ssr: false,
   loading: () => <CircularProgress size={180} />,
 })
 

--- a/src/components/TranslationSettings.js
+++ b/src/components/TranslationSettings.js
@@ -1,0 +1,108 @@
+import React, { useState, useEffect, useContext } from 'react'
+import PropTypes from 'prop-types'
+import { Paper } from 'translation-helps-rcl'
+import FormControl from '@material-ui/core/FormControl'
+import { makeStyles } from '@material-ui/core/styles'
+import InputLabel from '@material-ui/core/InputLabel'
+import MenuItem from '@material-ui/core/MenuItem'
+import Select from '@material-ui/core/Select'
+import { getGatewayLanguages } from '@common/languages'
+import { ReferenceContext } from '@context/ReferenceContext'
+
+const useStyles = makeStyles(theme => ({
+  formControl: {
+    marginTop: theme.spacing(3),
+    marginBottom: theme.spacing(3),
+    minWidth: '100%',
+  },
+}))
+
+export default function TranslationSettings({ authentication }) {
+  const classes = useStyles()
+  const [organizations, setOrganizations] = useState([])
+  const [languages, setLanguages] = useState([])
+  const {
+    state: { owner: organization, languageId },
+    actions: { setOwner: setOrganization, setLanguageId, setShowAccountSetup },
+  } = useContext(ReferenceContext)
+
+  useEffect(() => {
+    async function getOrgs() {
+      const orgs = await fetch('https://git.door43.org/api/v1/user/orgs', {
+        ...authentication.config,
+      })
+        .then(response => response.json())
+        .then(data => data.map(org => org.username))
+      setOrganizations(orgs)
+    }
+
+    if (authentication) {
+      getOrgs()
+    }
+  }, [authentication])
+
+  useEffect(() => {
+    async function getLanguages() {
+      const languages = await getGatewayLanguages()
+      setLanguages(languages || [])
+    }
+
+    getLanguages()
+  }, [])
+
+  const handleOrgChange = event => {
+    setOrganization(event.target.value)
+  }
+
+  const handleLanguageChange = event => {
+    setLanguageId(event.target.value)
+  }
+
+  return (
+    <Paper className='flex flex-col h-80 w-full p-6 pt-3 my-2'>
+      <h5>Translation Settings</h5>
+      <div className='flex flex-col justify-between my-4'>
+        <FormControl variant='outlined' className={classes.formControl}>
+          <InputLabel id='demo-simple-select-outlined-label'>
+            Organization
+          </InputLabel>
+          <Select
+            labelId='demo-simple-select-outlined-label'
+            id='demo-simple-select-outlined'
+            value={organization}
+            onChange={handleOrgChange}
+            label='Organization'
+          >
+            {organizations.map((org, i) => (
+              <MenuItem key={`${org}-${i}`} value={org}>
+                {org}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <FormControl variant='outlined' className={classes.formControl}>
+          <InputLabel id='demo-simple-select-outlined-label'>
+            Primary Translating Language
+          </InputLabel>
+          <Select
+            labelId='demo-simple-select-outlined-label'
+            id='demo-simple-select-outlined'
+            value={languageId}
+            onChange={handleLanguageChange}
+            label='Primary Translating Language'
+          >
+            {languages.map(({ languageId, languageName, localized }, i) => (
+              <MenuItem key={`${languageId}-${i}`} value={languageId}>
+                {`${languageId} - ${languageName} - ${localized}`}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </div>
+    </Paper>
+  )
+}
+
+TranslationSettings.propTypes = {
+  authentication: PropTypes.object.isRequired,
+}

--- a/src/components/WorkspaceContainer.js
+++ b/src/components/WorkspaceContainer.js
@@ -2,14 +2,15 @@ import { useContext } from 'react'
 import { Workspace } from 'resource-workspace-rcl'
 import { makeStyles } from '@material-ui/core/styles'
 import ResourceCard from '@components/ResourceCard'
-import ScriptureCard from "@components/ScriptureCard";
+import ScriptureCard from '@components/ScriptureCard'
 import { ReferenceContext } from '@context/ReferenceContext'
 import {
-  NT_BOOKS, NT_ORIG_LANG,
+  NT_BOOKS,
+  NT_ORIG_LANG,
   NT_ORIG_LANG_BIBLE,
   OT_ORIG_LANG,
-  OT_ORIG_LANG_BIBLE
-} from "@common/BooksOfTheBible";
+  OT_ORIG_LANG_BIBLE,
+} from '@common/BooksOfTheBible'
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -39,14 +40,20 @@ function WorkspaceContainer() {
   } = useContext(ReferenceContext)
 
   const layout = {
-    widths: [[1, 1, 1], [2, 2], [2, 2]],
+    widths: [
+      [1, 1, 1],
+      [2, 2],
+      [2, 2],
+    ],
   }
 
   // select original language Bible based on which testament the book is
-  const isNewTestament = NT_BOOKS.includes(bookId);
-  const originalLanguageID = isNewTestament ? NT_ORIG_LANG : OT_ORIG_LANG;
-  const originalBibleID = isNewTestament ? NT_ORIG_LANG_BIBLE : OT_ORIG_LANG_BIBLE;
-  const scriptureOwner = 'unfoldingWord'; //TODO blm: for testing use since test_org does not have enough bibles
+  const isNewTestament = NT_BOOKS.includes(bookId)
+  const originalLanguageID = isNewTestament ? NT_ORIG_LANG : OT_ORIG_LANG
+  const originalBibleID = isNewTestament
+    ? NT_ORIG_LANG_BIBLE
+    : OT_ORIG_LANG_BIBLE
+  const scriptureOwner = 'unfoldingWord' //TODO blm: for testing use since test_org does not have enough bibles
 
   return (
     <Workspace

--- a/src/context/ReferenceContext.js
+++ b/src/context/ReferenceContext.js
@@ -6,6 +6,10 @@ export const ReferenceContext = createContext({})
 export default function ReferenceContextProvider(props) {
   const [owner, setOwner] = useLocalStorage('owner', '')
   const [languageId, setLanguageId] = useLocalStorage('languageId', '')
+  const [showAccountSetup, setShowAccountSetup] = useLocalStorage(
+    'showAccountSetup',
+    true
+  )
   const [taArticle, setTaArticle] = useState(null)
   // TODO: To make the app more dynamic use the setters below to dynamically set and change the values
   const [server, setServer] = useState('https://git.door43.org')
@@ -40,6 +44,7 @@ export default function ReferenceContextProvider(props) {
 
   const value = {
     state: {
+      showAccountSetup,
       bibleReference,
       languageId,
       taArticle,
@@ -48,6 +53,7 @@ export default function ReferenceContextProvider(props) {
       owner,
     },
     actions: {
+      setShowAccountSetup,
       onReferenceChange,
       updateTaDetails,
       setLanguageId,


### PR DESCRIPTION
# Add Test Instructions

- [ ] Open https://deploy-preview-48--create-app.netlify.app/
- [ ] If logged in, the drawer should only have the account settings and feedback buttons
- [ ] Some drawer and app bar buttons were temporarily removed for V1 and will be added back once the features are made fully functional 
- [ ] Log in, should be prompted with `org` and `language` selection
- [ ] After selecting the `org` and `language` the `save and continue` button should be enabled
- [ ] Click the `save and continue` button and the `Resources Workspace` should render
- [ ] Open the app drawer and click on `Account Settings`, it should open the `Account Settings` page where you should be able to change your `org` and `language`.
- [ ] Change your `org` or `language` and click on the app name or the go back button on your browser to navigate to the main page (Resources Workspace)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/create-app/48)
<!-- Reviewable:end -->
