### PR TITLE
Feature/on layout change support and font size persist

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "regenerator-runtime": "^0.13.7",
-    "resource-workspace-rcl": "0.6.0-alpha",
+    "resource-workspace-rcl": "0.6.0",
     "scripture-resources-rcl": "3.2.0",
-    "single-scripture-rcl": "0.1.10",
+    "single-scripture-rcl": "0.1.11",
     "tailwindcss": "^2.0.2",
     "translation-helps-rcl": "1.4.0",
     "use-deep-compare-effect": "^1.3.1"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "regenerator-runtime": "^0.13.7",
-    "resource-workspace-rcl": "^0.5.0",
+    "resource-workspace-rcl": "0.6.0-alpha",
     "scripture-resources-rcl": "3.2.0",
     "single-scripture-rcl": "0.1.10",
     "tailwindcss": "^2.0.2",

--- a/src/components/WorkspaceContainer.js
+++ b/src/components/WorkspaceContainer.js
@@ -43,11 +43,13 @@ function WorkspaceContainer() {
         bookId, chapter, verse,
       },
       supportedBibles,
+      currentLayout,
     },
     actions: {
       updateTaDetails,
       setQuote,
       setSupportedBibles,
+      setCurrentLayout,
     },
   } = useContext(ReferenceContext)
 
@@ -58,6 +60,10 @@ function WorkspaceContainer() {
       [2, 2],
     ],
     heights: [[5], [10, 10], [10, 10]],
+  }
+
+  if (currentLayout) {
+    layout.absolute = currentLayout
   }
 
   function isNT(bookId) {
@@ -98,6 +104,7 @@ function WorkspaceContainer() {
       layout={layout}
       gridMargin={[15, 15]}
       classes={classes}
+      onLayoutChange={setCurrentLayout}
     >
       <ScriptureCard
         cardNum={0}

--- a/src/context/ReferenceContext.js
+++ b/src/context/ReferenceContext.js
@@ -24,6 +24,7 @@ export default function ReferenceContextProvider(props) {
   })
 
   const [supportedBibles, setSupportedBibles] = useLocalStorage('bibles', [])
+  const [currentLayout, setCurrentLayout] = useLocalStorage('resourceLayout', null)
 
   function onReferenceChange(bookId, chapter, verse) {
     setBibleReference(prevState => ({
@@ -59,6 +60,7 @@ export default function ReferenceContextProvider(props) {
       branch,
       owner,
       supportedBibles,
+      currentLayout,
     },
     actions: {
       setShowAccountSetup,
@@ -71,6 +73,7 @@ export default function ReferenceContextProvider(props) {
       setQuote,
       setOwner,
       setSupportedBibles,
+      setCurrentLayout,
     },
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6375,10 +6375,10 @@ resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.1
     is-core-module "^2.1.0"
     path-parse "^1.0.6"
 
-resource-workspace-rcl@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/resource-workspace-rcl/-/resource-workspace-rcl-0.5.0.tgz#32eebc90c833d4f5b038b41fe96b178172a834a3"
-  integrity sha512-2qEbZO4cPBlBcd2IReF6jl0XM0iZAK7p2VYKXFn0q897f+HECeznRSItZ+ycInvsqcC+CcuruqbRHfMDr5tNnA==
+resource-workspace-rcl@0.6.0-alpha:
+  version "0.6.0-alpha"
+  resolved "https://registry.yarnpkg.com/resource-workspace-rcl/-/resource-workspace-rcl-0.6.0-alpha.tgz#e1915f40bc39495a73b677e89931b46e9ea6c687"
+  integrity sha512-LHTM1CGxVwzcW1j7WHcCicFlusf9+ja11HHCGjCztEPmxvfs+Sxdlr3ZfE2aymmb7my/AtahSpAToSMw0kdNtg==
   dependencies:
     prop-types "^15.7.2"
     react-grid-layout "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6375,10 +6375,10 @@ resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.1
     is-core-module "^2.1.0"
     path-parse "^1.0.6"
 
-resource-workspace-rcl@0.6.0-alpha:
-  version "0.6.0-alpha"
-  resolved "https://registry.yarnpkg.com/resource-workspace-rcl/-/resource-workspace-rcl-0.6.0-alpha.tgz#e1915f40bc39495a73b677e89931b46e9ea6c687"
-  integrity sha512-LHTM1CGxVwzcW1j7WHcCicFlusf9+ja11HHCGjCztEPmxvfs+Sxdlr3ZfE2aymmb7my/AtahSpAToSMw0kdNtg==
+resource-workspace-rcl@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/resource-workspace-rcl/-/resource-workspace-rcl-0.6.0.tgz#73de1dd6e7343d06e4f26b634543a79469adb9a6"
+  integrity sha512-/s3iVZL5Awzx8xcrCWJAcqRq/8YwAEd1JO49LrwkMhU8ijdw35I6WH4g1Z11DQFueDR/Sy1yreXBnsjAK+vxkQ==
   dependencies:
     prop-types "^15.7.2"
     react-grid-layout "1.2.0"
@@ -6683,10 +6683,10 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
-single-scripture-rcl@0.1.10:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/single-scripture-rcl/-/single-scripture-rcl-0.1.10.tgz#d0f818ce012d356b4d1db6ef9eaac57b84df9e70"
-  integrity sha512-NUq5kh1yeaMe99Toj8czBKSe0L1soXliYgrY73Aq0XpGAXFll5h6qGquSiDBeuBJOEPd5XFI6sS+lyAJR/mO1w==
+single-scripture-rcl@0.1.11:
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/single-scripture-rcl/-/single-scripture-rcl-0.1.11.tgz#8c6c7bf7f7200645729d671a632da5c94c2ff44e"
+  integrity sha512-lY6XVojdwSdlngDRQxMX15a9ByCXqHD1jFsQxP1/LgCi6JAG0P8t4o/AhbukUvxuOiVCRytdSoVy22LAa/dTIQ==
   dependencies:
     "@types/react" "^17.0.0"
     "@types/react-dom" "^17.0.0"


### PR DESCRIPTION
## Describe what your pull request addresses
- [ ] added persistence of current layout to localStorage (issue https://github.com/unfoldingword/resource-workspace-rcl/issues/10)
- [ ] added persistence of font size to localStorage (issue https://github.com/unfoldingword/create-app/issues/6 - only pulls in latest single-scripture-rcl)

## Test Instructions
- can test with https://deploy-preview-60--create-app.netlify.app/

- [ ] in app move around and resize panels, then click refresh on browser.  Should see layout restored to last layout before refresh.
- [ ] change font size in various scripture panes, then click refresh on browser.  Should see font sizes restored to size  before refresh.


