### PR TITLE
Added appropriate message to translationAcademy Card when no article is available

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "scripture-resources-rcl": "4.0.0",
     "single-scripture-rcl": "1.0.1",
     "tailwindcss": "^2.0.2",
-    "translation-helps-rcl": "1.8.2",
+    "translation-helps-rcl": "^1.9.0-rc0",
     "use-deep-compare-effect": "^1.3.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "scripture-resources-rcl": "4.0.0",
     "single-scripture-rcl": "1.0.1",
     "tailwindcss": "^2.0.2",
-    "translation-helps-rcl": "^1.9.0-rc0",
+    "translation-helps-rcl": "1.9.0",
     "use-deep-compare-effect": "^1.3.1"
   },
   "devDependencies": {

--- a/src/components/ResourceCard.js
+++ b/src/components/ResourceCard.js
@@ -21,6 +21,7 @@ export default function ResourceCard({
   projectId,
   languageId,
   resourceId,
+  errorMessage,
   selectedQuote,
   disableFilters,
   updateTaDetails,
@@ -87,10 +88,13 @@ export default function ResourceCard({
         languageId={languageId}
         markdownView={markdownView}
         selectedQuote={selectedQuote}
+        errorMessage={errorMessage}
       />
     </Card>
   )
 }
+
+ResourceCard.defaultProps = { errorMessage: false }
 
 ResourceCard.propTypes = {
   viewMode: PropTypes.string,
@@ -111,4 +115,5 @@ ResourceCard.propTypes = {
   hideMarkdownToggle: PropTypes.bool,
   classes: PropTypes.object,
   selectedQuote: PropTypes.object,
+  errorMessage: PropTypes.string,
 }

--- a/src/components/WorkspaceContainer.js
+++ b/src/components/WorkspaceContainer.js
@@ -139,6 +139,8 @@ function WorkspaceContainer() {
     config,
   })
 
+  console.log({ taArticle })
+
   return (
     <SelectionsContextProvider
       selections={selections}
@@ -238,6 +240,7 @@ function WorkspaceContainer() {
           resourceId={'ta'}
           projectId={taArticle?.projectId}
           filePath={taArticle?.filePath}
+          errorMessage={taArticle ? null : 'No article is specified in the current note'}
         />
         <ResourceCard
           title='translationWords List'

--- a/src/components/WorkspaceContainer.js
+++ b/src/components/WorkspaceContainer.js
@@ -139,8 +139,6 @@ function WorkspaceContainer() {
     config,
   })
 
-  console.log({ taArticle })
-
   return (
     <SelectionsContextProvider
       selections={selections}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7407,10 +7407,10 @@ transform-runtime@0.0.0:
   resolved "https://registry.yarnpkg.com/transform-runtime/-/transform-runtime-0.0.0.tgz#e714d9b69211dd9537939d50e3aa5788c442b85c"
   integrity sha1-5xTZtpIR3ZU3k51Q46pXiMRCuFw=
 
-translation-helps-rcl@1.8.2:
-  version "1.8.2"
-  resolved "https://registry.yarnpkg.com/translation-helps-rcl/-/translation-helps-rcl-1.8.2.tgz#b169da51930128676623a6dc1056a6c2cbb17b1b"
-  integrity sha512-jqH5Ztf4h1CZlYQMwgpQ041Jc79LhCkB0GqS7WgEh8/UxNsp+yVMD02Ng+TIv9t6M08tNjNrm9pD4fXCEj1fnw==
+translation-helps-rcl@^1.9.0-rc0:
+  version "1.9.0-rc0"
+  resolved "https://registry.yarnpkg.com/translation-helps-rcl/-/translation-helps-rcl-1.9.0-rc0.tgz#0d6c939942f17e4c9dbcc0782bc6f704b936a48d"
+  integrity sha512-HWKeYxW1ur6DrSNlmSZ61mFhl8NSo9Cm8n+8J0YfSc6S17lYtA6uz0I1bpaSp0ML/vNyAdKnYIKl0szVmWHqVw==
   dependencies:
     react-draggable "^4.4.3"
     styled-components "^5.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7407,10 +7407,10 @@ transform-runtime@0.0.0:
   resolved "https://registry.yarnpkg.com/transform-runtime/-/transform-runtime-0.0.0.tgz#e714d9b69211dd9537939d50e3aa5788c442b85c"
   integrity sha1-5xTZtpIR3ZU3k51Q46pXiMRCuFw=
 
-translation-helps-rcl@^1.9.0-rc0:
-  version "1.9.0-rc0"
-  resolved "https://registry.yarnpkg.com/translation-helps-rcl/-/translation-helps-rcl-1.9.0-rc0.tgz#0d6c939942f17e4c9dbcc0782bc6f704b936a48d"
-  integrity sha512-HWKeYxW1ur6DrSNlmSZ61mFhl8NSo9Cm8n+8J0YfSc6S17lYtA6uz0I1bpaSp0ML/vNyAdKnYIKl0szVmWHqVw==
+translation-helps-rcl@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/translation-helps-rcl/-/translation-helps-rcl-1.9.0.tgz#c3c8a73b13cd5028cc65a25eda2e632794974f2b"
+  integrity sha512-pbAj8g4iuN3yHMqsf5l1QcaRe2JAqCAIn+NCE08ccFrFKOovYX+Ht2L90cXcFaR1R+6bxpa/4crooOoOXk19+g==
   dependencies:
     react-draggable "^4.4.3"
     styled-components "^5.2.1"


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ]

## Test Instructions

- [ ] Open https://deploy-preview-79--create-app.netlify.app/
- [ ] If the current note has an empty SupportReference field, the translation academy card should read `No article is specified in the current note` otherwise it should render the appropriate article 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/create-app/79)
<!-- Reviewable:end -->
